### PR TITLE
Monad transformers

### DIFF
--- a/lib/any.ml
+++ b/lib/any.ml
@@ -6,3 +6,4 @@ implicit module Any_Int = struct type t_for_any = int end
 implicit module Any_String = struct type t_for_any = string end
 implicit module Any_List {A : Any} = struct type t_for_any = A.t_for_any list end
 implicit module Any_Pair {A : Any} {B : Any} = struct type t_for_any = A.t_for_any * B.t_for_any end
+implicit module Any_Function {A : Any} {B : Any} = struct type t_for_any = A.t_for_any -> B.t_for_any end

--- a/lib/any.mli
+++ b/lib/any.mli
@@ -1,6 +1,11 @@
 module type Any = sig
   type t_for_any
 end
+(** Any is an interface that all types can and should implement.
+    Note: the type is called t_for_any instead of t, because otherwise
+    many existing modules could accidentally fit the Any module type,
+    which would make implicit resolution ambiguous.
+    *)
 
 implicit module Any_Int : Any with type t_for_any = int
 implicit module Any_String : Any with type t_for_any = string

--- a/lib/any.mli
+++ b/lib/any.mli
@@ -1,0 +1,9 @@
+module type Any = sig
+  type t_for_any
+end
+
+implicit module Any_Int : Any with type t_for_any = int
+implicit module Any_String : Any with type t_for_any = string
+implicit module Any_List {A : Any} : Any with type t_for_any = A.t_for_any list
+implicit module Any_Pair {A : Any} {B : Any} : Any with type t_for_any = A.t_for_any * B.t_for_any
+implicit module Any_Function {A : Any} {B : Any} : Any with type t_for_any = A.t_for_any -> B.t_for_any

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (public_name imp)
- (modules Any Control Data Scope Show)
+ (modules Any Control Data Scope Show Transformers)
  (synopsis "Experimental library using modular implicits"))

--- a/lib/transformers.ml
+++ b/lib/transformers.ml
@@ -3,17 +3,26 @@ open Control
 
 type ('r, 'am) readerT = ReaderT of ('r -> 'am)
 
-(* val runReaderT : 'a t -> R.t_for_any -> 'a M.t *)
-let runReaderT {R : Any} {M : Monad} (ReaderT f) = f
-let lift {R : Any} {M : Monad} m = ReaderT (fun _ -> m)
-let ask {R : Any} {M : Monad} = ReaderT (fun r -> return {M} r)
-let asks {R : Any} {M : Monad} f = ReaderT (fun r -> return {M} (f r))
-let local {R : Any} {M : Monad} f (ReaderT g) = ReaderT (fun r -> g (f r))
+let runReaderT {M : Monad} (ReaderT f) = f
+let runReader (ReaderT r) = r
+let lift {M : Monad} m = ReaderT (fun _ -> m)
+
+module type MonadReader = sig
+  include Monad
+  type r
+  val asks : (r -> 'b) -> 'b t
+  val local : (r -> r) -> r t -> r t
+end
+
+let asks {M : MonadReader} = M.asks
+let local {M : MonadReader} = M.local
+let ask {M : MonadReader} = asks (fun r -> r)
 
 implicit module ReaderT {R : Any} {M : Monad} : sig
   include Functor with type 'a t = (R.t_for_any, 'a M.t) readerT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
+  include MonadReader with type 'a t := 'a t and type r = R.t_for_any
 end = struct
   type 'a t = (R.t_for_any, 'a M.t) readerT
   (* Functor *)
@@ -22,5 +31,29 @@ end = struct
   let return x = ReaderT (fun _ -> return {M} x)
   let apply (ReaderT ff) (ReaderT fx) = ReaderT (fun r -> apply {M} (ff r) (fx r))
   (* Monad *)
-  let bind (ReaderT fx) ff = ReaderT (fun r -> bind {M} (fx r) (fun a -> runReaderT {R} {M} (ff a) r))
+  let bind (ReaderT fx) ff = ReaderT (fun r -> bind {M} (fx r) (fun a -> runReaderT {M} (ff a) r))
+  (* MonadReader *)
+  type r = R.t_for_any
+  let asks f = ReaderT (fun r -> M.return (f r))
+  let local f (ReaderT g) = ReaderT (fun r -> g (f r))
+end
+
+implicit module Reader {R : Any} : sig
+  include Functor with type 'a t = (R.t_for_any, 'a) readerT
+  include Applicative with type 'a t := 'a t
+  include Monad with type 'a t := 'a t
+  include MonadReader with type 'a t := 'a t and type r = R.t_for_any
+end = struct
+  type 'a t = (R.t_for_any, 'a) readerT
+  (* Functor *)
+  let fmap f (ReaderT m) = ReaderT (fun r -> f (m r))
+  (* Applicative *)
+  let return x = ReaderT (fun _ -> x)
+  let apply (ReaderT ff) (ReaderT fx) = ReaderT (fun r -> ff r (fx r))
+  (* Monad *)
+  let bind (ReaderT fx) ff = ReaderT (fun r -> runReader (ff (fx r)) r)
+  (* MonadReader *)
+  type r = R.t_for_any
+  let asks f = ReaderT f
+  let local f (ReaderT g) = ReaderT (fun r -> g (f r))
 end

--- a/lib/transformers.ml
+++ b/lib/transformers.ml
@@ -1,0 +1,26 @@
+open Any
+open Control
+
+type ('r, 'am) readerT = ReaderT of ('r -> 'am)
+
+(* val runReaderT : 'a t -> R.t_for_any -> 'a M.t *)
+let runReaderT {R : Any} {M : Monad} (ReaderT f) = f
+let lift {R : Any} {M : Monad} m = ReaderT (fun _ -> m)
+let ask {R : Any} {M : Monad} = ReaderT (fun r -> return {M} r)
+let asks {R : Any} {M : Monad} f = ReaderT (fun r -> return {M} (f r))
+let local {R : Any} {M : Monad} f (ReaderT g) = ReaderT (fun r -> g (f r))
+
+implicit module ReaderT {R : Any} {M : Monad} : sig
+  include Functor with type 'a t = (R.t_for_any, 'a M.t) readerT
+  include Applicative with type 'a t := 'a t
+  include Monad with type 'a t := 'a t
+end = struct
+  type 'a t = (R.t_for_any, 'a M.t) readerT
+  (* Functor *)
+  let fmap f (ReaderT m) = ReaderT (fun r -> fmap {M} f (m r))
+  (* Applicative *)
+  let return x = ReaderT (fun _ -> return {M} x)
+  let apply (ReaderT ff) (ReaderT fx) = ReaderT (fun r -> apply {M} (ff r) (fx r))
+  (* Monad *)
+  let bind (ReaderT fx) ff = ReaderT (fun r -> bind {M} (fx r) (fun a -> runReaderT {R} {M} (ff a) r))
+end

--- a/lib/transformers.mli
+++ b/lib/transformers.mli
@@ -1,0 +1,33 @@
+open Any
+open Control
+
+type ('r, 'am) readerT
+
+val runReaderT : {M : Monad} -> ('r, 'a M.t) readerT -> 'r -> 'a M.t
+val runReader : ('r, 'a) readerT -> 'r -> 'a
+val lift : {M : Monad} -> 'a M.t -> ('r, 'a M.t) readerT
+
+module type MonadReader = sig
+  include Monad
+  type r
+  val asks : (r -> 'b) -> 'b t
+  val local : (r -> r) -> r t -> r t
+end
+
+val asks : {M : MonadReader} -> (M.r -> 'b) -> 'b M.t
+val local : {M : MonadReader} -> (M.r -> M.r) -> M.r M.t -> M.r M.t
+val ask : {M : MonadReader} -> M.r M.t
+
+implicit module ReaderT {R : Any} {M : Monad} : sig
+  include Functor with type 'a t = (R.t_for_any, 'a M.t) readerT
+  include Applicative with type 'a t := 'a t
+  include Monad with type 'a t := 'a t
+  include MonadReader with type 'a t := 'a t and type r = R.t_for_any
+end
+
+implicit module Reader {R : Any} : sig
+  include Functor with type 'a t = (R.t_for_any, 'a) readerT
+  include Applicative with type 'a t := 'a t
+  include Monad with type 'a t := 'a t
+  include MonadReader with type 'a t := 'a t and type r = R.t_for_any
+end

--- a/lib/transformers.mli
+++ b/lib/transformers.mli
@@ -2,10 +2,19 @@ open Any
 open Control
 
 type ('r, 'am) readerT
+(** The Reader and ReaderT monads.
+    For ReaderT, transforming an inner monad m, use ('r, 'a m) readerT
+    For Reader, with no inner monad, use ('r 'a) readerT
+ *)
 
 val runReaderT : {M : Monad} -> ('r, 'a M.t) readerT -> 'r -> 'a M.t
+(** Run a readerT monad using the given read-only state value *)
+
 val runReader : ('r, 'a) readerT -> 'r -> 'a
+(** Run a reader monad using the given read-only state value *)
+
 val lift : {M : Monad} -> 'a M.t -> ('r, 'a M.t) readerT
+(** Lift a value from the inner monad m to the transformed monad, ('r 'a m) readerT *)
 
 module type MonadReader = sig
   include Monad
@@ -13,10 +22,19 @@ module type MonadReader = sig
   val asks : (r -> 'b) -> 'b t
   val local : (r -> r) -> r t -> r t
 end
+(** MonadReader allows the functions ask, asks, and local
+    to be generalised to both reader and readerT
+    (both those types implement MonadReader)
+ *)
 
 val asks : {M : MonadReader} -> (M.r -> 'b) -> 'b M.t
+(** asks reads the state, applying a given transformation to it *)
+
 val local : {M : MonadReader} -> (M.r -> M.r) -> M.r M.t -> M.r M.t
+(** local runs the given reader monad using a transformed version of the state. *)
+
 val ask : {M : MonadReader} -> M.r M.t
+(** ask reads the state of the monad *)
 
 implicit module ReaderT {R : Any} {M : Monad} : sig
   include Functor with type 'a t = (R.t_for_any, 'a M.t) readerT

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -88,3 +88,10 @@ let () =
   let open Imp.Control in
   let open implicit Imp.Any in
   assert (fmap (fun x -> x + 1) ("hello", 3) = ("hello", 4))
+
+let () =
+  let open Imp.Any in
+  let open Imp.Control in
+  let open Imp.Transformers in
+  let test = bind {ReaderT {Any_String} {Option}} (ask {Any_String} {Option}) (fun x -> lift {Any_String} {Option} (Some (x ^ "!"))) in
+  assert (runReaderT {Any_String} {Option} test "hello" = Some "hello!")

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -93,5 +93,11 @@ let () =
   let open Imp.Any in
   let open Imp.Control in
   let open Imp.Transformers in
-  let test = bind {ReaderT {Any_String} {Option}} (ask {Any_String} {Option}) (fun x -> lift {Any_String} {Option} (Some (x ^ "!"))) in
-  assert (runReaderT {Any_String} {Option} test "hello" = Some "hello!")
+  let module R = ReaderT {Any_String} {Option} in
+  let test = bind {R} (ask {R}) (fun x -> return [x ^ "!"]) in
+  assert (runReaderT {Option} test "hello" = Some ["hello!"]);
+  let test = bind {R} (ask {R}) (fun _ -> lift {Option} None) in
+  assert (runReaderT {Option} test "hello" = None);
+  let module R = Reader {Any_String} in
+  let test = bind {R} (ask {R}) (fun x -> return [x ^ "!"]) in
+  assert (runReader test "hello" = ["hello!"])


### PR DESCRIPTION
For now only ReaderT, as a proof-of-concept

Observations:
- compilation is really slow now
- the compiler frequently errors with `Error: Termination check failed when searching for implicit M.` - Is this maybe because it's trying (e.g.) `Option`, then `ReaderT _ Option`, then `ReaderT _ (ReaderT _ Option)`, then `ReaderT _ (ReaderT _ (ReaderT _ Option))`, etc., as it can produce infnitely many monads if it wants?