### PR TITLE
Add First monoid

### DIFF
--- a/lib/data.ml
+++ b/lib/data.ml
@@ -105,9 +105,20 @@ end
 module Monoid = struct
   let empty {M : Monoid} () = M.empty
   let append {M : Monoid} = M.append
+
+  type 'a first = { first: 'a option }
 end
 
 (* Instances *)
+
+implicit module First {A: Any} : Monoid with type t = A.t_for_any Monoid.first = struct
+  open Monoid
+  type t = A.t_for_any first
+  let empty = { first = None }
+  let append x y = match x with
+    | { first = Some _ } -> x
+    | { first = None } -> y
+end
 
 implicit module Int: sig
   include Eq with type t = int
@@ -358,13 +369,3 @@ implicit module Unit: Monoid with type t = unit = struct
 end
 
 type 'b nonEmpty = NonEmpty of 'b * 'b list
-
-type 'a first = { first: 'a option }
-
-implicit module First {A: Any} : Monoid with type t = A.t_for_any first = struct
-  type t = A.t_for_any first
-  let empty = { first = None }
-  let append x y = match x with
-    | { first = Some _ } -> x
-    | { first = None } -> y
-end

--- a/lib/data.ml
+++ b/lib/data.ml
@@ -358,3 +358,13 @@ implicit module Unit: Monoid with type t = unit = struct
 end
 
 type 'b nonEmpty = NonEmpty of 'b * 'b list
+
+type 'a first = { first: 'a option }
+
+implicit module First {A: Any} : Monoid with type t = A.t_for_any first = struct
+  type t = A.t_for_any first
+  let empty = { first = None }
+  let append x y = match x with
+    | { first = Some _ } -> x
+    | { first = None } -> y
+end

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -130,8 +130,9 @@ let () =
 let () =
   let open Imp.Any in
   let open Imp.Data in
-  let e : int first = Monoid.empty {First {Any_Int}} () in
+  let open Monoid in
+  let e : int first = empty {First {Any_Int}} () in
   assert (e = { first = None });
-  assert (Monoid.append e e = e);
-  assert (Monoid.append {First {Any_Int}} { first = Some 2 } e = { first = Some 2 });
-  assert (Monoid.append {First {Any_Int}} { first = Some 2 } { first = Some 3 } = { first = Some 2 })
+  assert (append e e = e);
+  assert (append {First {Any_Int}} { first = Some 2 } e = { first = Some 2 });
+  assert (append {First {Any_Int}} { first = Some 2 } { first = Some 3 } = { first = Some 2 })

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -126,3 +126,12 @@ let () =
   let open Imp.Data in
   assert (5 = extract (Identity 5));
   assert (10 = extract  (NonEmpty (10, [])))
+
+let () =
+  let open Imp.Any in
+  let open Imp.Data in
+  let e : int first = Monoid.empty {First {Any_Int}} () in
+  assert (e = { first = None });
+  assert (Monoid.append e e = e);
+  assert (Monoid.append {First {Any_Int}} { first = Some 2 } e = { first = Some 2 });
+  assert (Monoid.append {First {Any_Int}} { first = Some 2 } { first = Some 3 } = { first = Some 2 })


### PR DESCRIPTION
`First` returns the left-most non-`None` value. See Haskell's [Data.Monoid.First](https://hackage.haskell.org/package/base-4.18.0.0/docs/Data-Monoid.html#t:First)
