### PR TITLE
Rename `t_for_any` to `t`, and use a different marker system for `Any` instances

### DIFF
--- a/lib/any.ml
+++ b/lib/any.ml
@@ -1,9 +1,29 @@
 module type Any = sig
-  type t_for_any
+  type t
+  val __any__ : unit
 end
 
-implicit module Any_Int = struct type t_for_any = int end
-implicit module Any_String = struct type t_for_any = string end
-implicit module Any_List {A : Any} = struct type t_for_any = A.t_for_any list end
-implicit module Any_Pair {A : Any} {B : Any} = struct type t_for_any = A.t_for_any * B.t_for_any end
-implicit module Any_Function {A : Any} {B : Any} = struct type t_for_any = A.t_for_any -> B.t_for_any end
+implicit module Any_Int = struct
+  type t = int
+  let __any__ = ()
+end
+
+implicit module Any_String = struct
+  type t = string
+  let __any__ = ()
+end
+
+implicit module Any_List {A : Any} = struct
+  type t = A.t list
+  let __any__ = ()
+end
+
+implicit module Any_Pair {A : Any} {B : Any} = struct
+  type t = A.t * B.t
+  let __any__ = ()
+end
+
+implicit module Any_Function {A : Any} {B : Any} = struct
+  type t = A.t -> B.t
+  let __any__ = ()
+end

--- a/lib/any.mli
+++ b/lib/any.mli
@@ -1,14 +1,15 @@
 module type Any = sig
-  type t_for_any
+  type t
+  val __any__ : unit
 end
 (** Any is an interface that all types can and should implement.
-    Note: the type is called t_for_any instead of t, because otherwise
+    Note: the type has the extraneous member __any__, because otherwise
     many existing modules could accidentally fit the Any module type,
     which would make implicit resolution ambiguous.
     *)
 
-implicit module Any_Int : Any with type t_for_any = int
-implicit module Any_String : Any with type t_for_any = string
-implicit module Any_List {A : Any} : Any with type t_for_any = A.t_for_any list
-implicit module Any_Pair {A : Any} {B : Any} : Any with type t_for_any = A.t_for_any * B.t_for_any
-implicit module Any_Function {A : Any} {B : Any} : Any with type t_for_any = A.t_for_any -> B.t_for_any
+implicit module Any_Int : Any with type t = int
+implicit module Any_String : Any with type t = string
+implicit module Any_List {A : Any} : Any with type t = A.t list
+implicit module Any_Pair {A : Any} {B : Any} : Any with type t = A.t * B.t
+implicit module Any_Function {A : Any} {B : Any} : Any with type t = A.t -> B.t

--- a/lib/comonads.ml
+++ b/lib/comonads.ml
@@ -35,10 +35,10 @@ implicit module CoNonEmpty : sig
   end
 
 implicit module CoPair {A : Any} : sig
-include Functor with type 'b t = A.t_for_any * 'b
+include Functor with type 'b t = A.t * 'b
 include CoMonad with type 'b t := 'b t
 end = struct
-  type 'b t = A.t_for_any * 'b
+  type 'b t = A.t * 'b
   let fmap f (a, b) = (a, f b)
   let extract (_, b) = b
   let duplicate (a, b) = (a, (a, b))

--- a/lib/control.ml
+++ b/lib/control.ml
@@ -180,11 +180,11 @@ end = struct
 end
 
 implicit module Function {A : Any} : sig
-  include Functor with type 'b t = A.t_for_any -> 'b
+  include Functor with type 'b t = A.t -> 'b
   include Applicative with type 'b t := 'b t
   include Monad with type 'b t := 'b t
 end = struct
-  type 'b t = A.t_for_any -> 'b
+  type 'b t = A.t -> 'b
 
   (* Functor *)
   let fmap m f x = m (f x)
@@ -198,8 +198,8 @@ end = struct
 end
 (** (a -> b) is an instance of Monad b - it behaves like the reader monad *)
 
-implicit module Pair {A : Any} : Functor with type 'b t = A.t_for_any * 'b = struct
-  type 'b t = A.t_for_any * 'b
+implicit module Pair {A : Any} : Functor with type 'b t = A.t * 'b = struct
+  type 'b t = A.t * 'b
 
   let fmap m (a, b) = (a, m b)
 end
@@ -207,9 +207,9 @@ end
 type ('a, 'b) const = Const of 'a
 
 implicit module Const {A : Any}: sig
-  include Functor with type 'b t = (A.t_for_any, 'b) const
+  include Functor with type 'b t = (A.t, 'b) const
 end = struct
-  type 'b t = (A.t_for_any, 'b) const
+  type 'b t = (A.t, 'b) const
   let fmap _ (Const x) = (Const x)
 end
 

--- a/lib/data.ml
+++ b/lib/data.ml
@@ -111,9 +111,9 @@ end
 
 (* Instances *)
 
-implicit module First {A: Any} : Monoid with type t = A.t_for_any Monoid.first = struct
+implicit module First {A: Any} : Monoid with type t = A.t Monoid.first = struct
   open Monoid
-  type t = A.t_for_any first
+  type t = A.t first
   let empty = { first = None }
   let append x y = match x with
     | { first = Some _ } -> x
@@ -253,8 +253,8 @@ end = struct
   let append = (^)
 end
 
-module List {A : Any} : Monoid with type t = A.t_for_any list = struct
-  type t = A.t_for_any list
+module List {A : Any} : Monoid with type t = A.t list = struct
+  type t = A.t list
 
   (* Monoid *)
   let empty = []

--- a/lib/transformers.ml
+++ b/lib/transformers.ml
@@ -18,12 +18,12 @@ let local {M : MonadReader} = M.local
 let ask {M : MonadReader} = asks (fun r -> r)
 
 implicit module ReaderT {R : Any} {M : Monad} : sig
-  include Functor with type 'a t = (R.t_for_any, 'a M.t) readerT
+  include Functor with type 'a t = (R.t, 'a M.t) readerT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
-  include MonadReader with type 'a t := 'a t and type r = R.t_for_any
+  include MonadReader with type 'a t := 'a t and type r = R.t
 end = struct
-  type 'a t = (R.t_for_any, 'a M.t) readerT
+  type 'a t = (R.t, 'a M.t) readerT
   (* Functor *)
   let fmap f (ReaderT m) = ReaderT (fun r -> fmap {M} f (m r))
   (* Applicative *)
@@ -32,18 +32,18 @@ end = struct
   (* Monad *)
   let bind (ReaderT fx) ff = ReaderT (fun r -> bind {M} (fx r) (fun a -> runReaderT {M} (ff a) r))
   (* MonadReader *)
-  type r = R.t_for_any
+  type r = R.t
   let asks f = ReaderT (fun r -> M.return (f r))
   let local f (ReaderT g) = ReaderT (fun r -> g (f r))
 end
 
 implicit module Reader {R : Any} : sig
-  include Functor with type 'a t = (R.t_for_any, 'a) readerT
+  include Functor with type 'a t = (R.t, 'a) readerT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
-  include MonadReader with type 'a t := 'a t and type r = R.t_for_any
+  include MonadReader with type 'a t := 'a t and type r = R.t
 end = struct
-  type 'a t = (R.t_for_any, 'a) readerT
+  type 'a t = (R.t, 'a) readerT
   (* Functor *)
   let fmap f (ReaderT m) = ReaderT (fun r -> f (m r))
   (* Applicative *)
@@ -52,7 +52,7 @@ end = struct
   (* Monad *)
   let bind (ReaderT fx) ff = ReaderT (fun r -> runReader (ff (fx r)) r)
   (* MonadReader *)
-  type r = R.t_for_any
+  type r = R.t
   let asks f = ReaderT f
   let local f (ReaderT g) = ReaderT (fun r -> g (f r))
 end
@@ -70,12 +70,12 @@ module type MonadState = sig
 end
 
 implicit module StateT {S : Any} {M : Monad} : sig
-  include Functor with type 'a t = (S.t_for_any, ('a * S.t_for_any) M.t) stateT
+  include Functor with type 'a t = (S.t, ('a * S.t) M.t) stateT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
-  include MonadState with type 'a t := 'a t and type s = S.t_for_any
+  include MonadState with type 'a t := 'a t and type s = S.t
 end = struct
-  type 'a t = (S.t_for_any, ('a * S.t_for_any) M.t) stateT
+  type 'a t = (S.t, ('a * S.t) M.t) stateT
   (* Functor *)
   let fmap (f: 'a -> 'b) (StateT m: 'a t): 'b t = StateT (
     fun s -> M.fmap (fun (x, s') -> (f x, s')) (m s)
@@ -93,7 +93,7 @@ end = struct
     fun (a, s') -> runStateT {M} (ff a) s'
   )
   (* MonadState *)
-  type s = S.t_for_any
+  type s = S.t
   let get = StateT (fun s -> M.return (s, s))
   let put s = StateT (fun _ -> M.return ((), s))
 end
@@ -105,12 +105,12 @@ let gets {M: MonadState} f = fmap f M.get
 let modify {M: MonadState} f = bind M.get (fun s -> M.put (f s))
 
 implicit module State {S : Any} : sig
-  include Functor with type 'a t = (S.t_for_any, 'a * S.t_for_any) stateT
+  include Functor with type 'a t = (S.t, 'a * S.t) stateT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
-  include MonadState with type 'a t := 'a t and type s = S.t_for_any
+  include MonadState with type 'a t := 'a t and type s = S.t
 end = struct
-  type 'a t = (S.t_for_any, 'a * S.t_for_any) stateT
+  type 'a t = (S.t, 'a * S.t) stateT
   (* Functor *)
   let fmap (f: 'a -> 'b) (StateT m: 'a t): 'b t = StateT (
     fun s ->
@@ -130,7 +130,7 @@ end = struct
     runState (ff a) s'
   )
   (* MonadState *)
-  type s = S.t_for_any
+  type s = S.t
   let get = StateT (fun s -> (s, s))
   let put s = StateT (fun _ -> ((), s))
 end
@@ -144,7 +144,7 @@ end
 let lift {T: MonadTrans} = T.lift
 
 implicit module ReaderT_Trans {R: Any} {M: Monad}: MonadTrans
-  with type 'a MT.t = (R.t_for_any, 'a M.t) readerT
+  with type 'a MT.t = (R.t, 'a M.t) readerT
   and type 'a M.t = 'a M.t
 = struct
   module M = M
@@ -153,7 +153,7 @@ implicit module ReaderT_Trans {R: Any} {M: Monad}: MonadTrans
 end
 
 implicit module StateT_Trans {S: Any} {M: Monad}: MonadTrans
-  with type 'a MT.t = (S.t_for_any, ('a * S.t_for_any) M.t) stateT
+  with type 'a MT.t = (S.t, ('a * S.t) M.t) stateT
   and type 'a M.t = 'a M.t
 = struct
   module M = M

--- a/lib/transformers.mli
+++ b/lib/transformers.mli
@@ -34,17 +34,17 @@ val ask : {M : MonadReader} -> M.r M.t
 (** ask reads the state of the monad *)
 
 implicit module ReaderT {R : Any} {M : Monad} : sig
-  include Functor with type 'a t = (R.t_for_any, 'a M.t) readerT
+  include Functor with type 'a t = (R.t, 'a M.t) readerT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
-  include MonadReader with type 'a t := 'a t and type r = R.t_for_any
+  include MonadReader with type 'a t := 'a t and type r = R.t
 end
 
 implicit module Reader {R : Any} : sig
-  include Functor with type 'a t = (R.t_for_any, 'a) readerT
+  include Functor with type 'a t = (R.t, 'a) readerT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
-  include MonadReader with type 'a t := 'a t and type r = R.t_for_any
+  include MonadReader with type 'a t := 'a t and type r = R.t
 end
 
 type ('s, +'asm) stateT
@@ -81,17 +81,17 @@ val modify : {M : MonadState} -> (M.s -> M.s) -> unit M.t
 (** modify applies a given transformation to the state *)
 
 implicit module StateT {S : Any} {M : Monad} : sig
-  include Functor with type 'a t = (S.t_for_any, ('a * S.t_for_any) M.t) stateT
+  include Functor with type 'a t = (S.t, ('a * S.t) M.t) stateT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
-  include MonadState with type 'a t := 'a t and type s = S.t_for_any
+  include MonadState with type 'a t := 'a t and type s = S.t
 end
 
 implicit module State {S : Any} : sig
-  include Functor with type 'a t = (S.t_for_any, 'a * S.t_for_any) stateT
+  include Functor with type 'a t = (S.t, 'a * S.t) stateT
   include Applicative with type 'a t := 'a t
   include Monad with type 'a t := 'a t
-  include MonadState with type 'a t := 'a t and type s = S.t_for_any
+  include MonadState with type 'a t := 'a t and type s = S.t
 end
 
 module type MonadTrans = sig
@@ -111,10 +111,10 @@ val lift : {T: MonadTrans} -> 'a T.M.t -> 'a T.MT.t
  *)
 
 implicit module ReaderT_Trans {R: Any} {M: Monad}: MonadTrans
-  with type 'a MT.t = (R.t_for_any, 'a M.t) readerT
+  with type 'a MT.t = (R.t, 'a M.t) readerT
   and type 'a M.t = 'a M.t
 
 implicit module StateT_Trans {S: Any} {M: Monad}: MonadTrans
-  with type 'a MT.t = (S.t_for_any, ('a * S.t_for_any) M.t) stateT
+  with type 'a MT.t = (S.t, ('a * S.t) M.t) stateT
   and type 'a M.t = 'a M.t
 


### PR DESCRIPTION
I decided `t_for_any` was a confusing an unwieldy name, so I renamed it back to `t`, and now I'm using the "blessing signatures" pattern (see [here](https://cambium.inria.fr/seminaires/transparents/20160314.Jacques.Garrigue.pdf), slide 25)