### PR TITLE
Use let operator syntax for Monads

### DIFF
--- a/imp.opam
+++ b/imp.opam
@@ -17,6 +17,6 @@ build: [
 depends: [
    "dune" {build}
    "ocaml-variants"
-     { = "4.02.1+modular-implicits" | = "4.02.1+modular-implicits-ber" }
+     { = "4.02.1+modular-implicits+let_syntax" }
 ]
 

--- a/lib/control.ml
+++ b/lib/control.ml
@@ -140,7 +140,7 @@ end = struct
 
   (* Foldable *)
   let fold f t acc = match t with
-    | (Left x) -> acc
+    | (Left _) -> acc
     | (Right x) -> f x acc
 
   (* Traversable *)
@@ -205,6 +205,9 @@ let fix (f : 'a -> 'a) : 'a =
   let rec loop x = let x' = f x in
      if x = x' then x else loop x' in loop (Obj.magic ())
 
+exception Head
+exception Tail
+
 implicit module List : sig
   include Functor with type 'a t = 'a list
   include Applicative with type 'a t := 'a t
@@ -231,8 +234,12 @@ end = struct
   let mzero = []
   let mplus = (@)
 
-  let head (x::_) = x
-  let tail (_::xs) = xs
+  let head = function
+    | (x::_) -> x
+    | [] -> raise Head
+  let tail = function
+    | (_::xs) -> xs
+    | [] -> raise Tail
 
   (* Monad_fix *)
   let rec mfix (f : 'a -> 'a list) : 'a list = match fix (fun x -> f (head x)) with 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -20,9 +20,7 @@ let () =
     assert (None = liftA2 ( + ) x None);
     end
 
-
 let () =
-  let open Imp.Data.Fractional in
   let open Imp.Data.Floating in
   let open Imp.Data.Num in
   let open implicit Imp.Data in
@@ -35,8 +33,6 @@ let () =
     assert ( 0.1 > 6.29 - (y + x));
 end
 
-
-    
 let () =
   begin
     (* Locally bind implicit instance *)
@@ -162,7 +158,7 @@ let () =
   assert (append {First {Any_Int}} { first = Some 2 } e = { first = Some 2 });
   assert (append {First {Any_Int}} { first = Some 2 } { first = Some 3 } = { first = Some 2 })
 
-  let () =
+let () =
   let open Imp.Control in
-  let f = fun x -> Some 5 in
+  let f = fun _ -> Some 5 in
     assert ((mfix f) = (Some 5))

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -135,7 +135,7 @@ let () =
   let module S = State {Any_String} in
   let test = bind {S} (get {S}) (fun x -> return [x ^ "!"]) in
   assert (runState test "hello" = (["hello!"], "hello"));
-  let (>>) {M: Monad} x y = M.bind x (fun _ -> y) in
+  let (>>) {M: Monad} x y = M.(let* _ = x in y) in
   let test = bind {S} (put {S} "goodbye" >> get {S}) (fun x -> return [x ^ "!"]) in
   assert (runState test "hello" = (["goodbye!"], "goodbye"));
   let test = bind {S} (modify {S} (fun x -> x ^ "!") >> get {S}) (fun x -> return [x ^ "!"]) in
@@ -162,3 +162,10 @@ let () =
   let open Imp.Control in
   let f = fun _ -> Some 5 in
     assert ((mfix f) = (Some 5))
+
+let () = ignore begin
+  let open Imp.Control in
+  let open Option in
+  let* x = Some 3 in
+  return (assert (x = 3))
+end


### PR DESCRIPTION
The `let*` thing works pretty well for generalised functions like sequence:
```ocaml
let sequence {M : Monad'} (ms : 'a M.t list) =
  let open M in
  List.fold_right
    (fun m m' ->
      let* x = m in
      let* xs = m' in
      return (x :: xs))
    ms
    (return [])
```

But for monomorphic monadic code like this, you have to mention the name of the Monad instance.

```ocaml
let open Imp.Control in
let open Option in
let* x = Some 3 in
return (assert (x = 3))
```
